### PR TITLE
GitHub Release publishing tweaks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,9 @@ publisher {
     // Tag to use for GitHub release. Defaults to version
     setGithubTag("v${project.version}")
 
+    // Whether to create a tag for the GitHub release, if one doesn't exist yet. Defaults to true
+    setCreateGithubTag(true)
+
     // Whether to create the GitHub release if it doesn't exist yet. Defaults to true
     setCreateGithubRelease(true)
 
@@ -253,6 +256,9 @@ publisher {
 
     // Tag to use for GitHub release. Defaults to version
     githubTag.set("v${project.version}")
+
+    // Whether to create a tag for the GitHub release, if one doesn't exist yet. Defaults to true
+    createGithubTag.set(true)
     
     // Whether to create the GitHub release if it doesn't exist yet. Defaults to true
     createGithubRelease.set(true)

--- a/readme.md
+++ b/readme.md
@@ -76,18 +76,6 @@ publisher {
     // Required for Modrinth/GitHub
     setVersion("1.20.2-${project.version}")
     
-    // Tag to use for GitHub release. Defaults to version
-    setGithubTag("v${project.version}")
-
-    // Whether to create a tag for the GitHub release, if one doesn't exist yet. Defaults to true
-    setCreateGithubTag(true)
-
-    // Whether to create the GitHub release if it doesn't exist yet. Defaults to true
-    setCreateGithubRelease(true)
-
-    // Whether to update the GitHub release if it already exists. Defaults to true
-    setUpdateGithubRelease(true)
-    
     // Fancy display name for the upload.
     // Will default to the project version if not set
     setDisplayName("[1.20.x] Simple Discord Link - ${project.version}")
@@ -145,6 +133,21 @@ publisher {
 Additional values that can be added to the above:
 
 ```groovy
+// GitHub options
+github {
+    // Tag to use for GitHub release. Defaults to version
+    tag = "v${project.version}"
+
+    // Whether to create a tag for the GitHub release, if one doesn't exist yet. Defaults to true
+    createTag = true
+
+    // Whether to create the GitHub release if it doesn't exist yet. Defaults to true
+    createRelease = true
+
+    // Whether to update the GitHub release if it already exists. Defaults to true
+    updateRelease = true
+}
+
 // Modrinth Dependencies.
 // Accepts a slug or id
 modrinthDepends {
@@ -253,18 +256,6 @@ publisher {
     
     // Required for Modrinth/GitHub
     version.set("1.3.0")
-
-    // Tag to use for GitHub release. Defaults to version
-    githubTag.set("v${project.version}")
-
-    // Whether to create a tag for the GitHub release, if one doesn't exist yet. Defaults to true
-    createGithubTag.set(true)
-    
-    // Whether to create the GitHub release if it doesn't exist yet. Defaults to true
-    createGithubRelease.set(true)
-    
-    // Whether to update the GitHub release if it already exists. Defaults to true
-    updateGithubRelease.set(true)
     
     // Fancy display name for the upload.
     // Will default to the project version if not set
@@ -325,6 +316,21 @@ publisher {
 Additional values that can be added to the above:
 
 ```kotlin
+// GitHub options
+github {
+    // Tag to use for GitHub release. Defaults to version
+    tag = "v${project.version}"
+
+    // Whether to create a tag for the GitHub release, if one doesn't exist yet. Defaults to true
+    createTag = true
+
+    // Whether to create the GitHub release if it doesn't exist yet. Defaults to true
+    createRelease = true
+
+    // Whether to update the GitHub release if it already exists. Defaults to true
+    updateRelease = true
+}
+
 // Modrinth Dependencies.
 // Accepts a slug or id
 modrinthDepends {

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,12 @@ publisher {
     
     // Tag to use for GitHub release. Defaults to version
     setGithubTag("v${project.version}")
+
+    // Whether to create the GitHub release if it doesn't exist yet. Defaults to true
+    setCreateGithubRelease(true)
+
+    // Whether to update the GitHub release if it already exists. Defaults to true
+    setUpdateGithubRelease(true)
     
     // Fancy display name for the upload.
     // Will default to the project version if not set
@@ -247,6 +253,12 @@ publisher {
 
     // Tag to use for GitHub release. Defaults to version
     githubTag.set("v${project.version}")
+    
+    // Whether to create the GitHub release if it doesn't exist yet. Defaults to true
+    createGithubRelease.set(true)
+    
+    // Whether to update the GitHub release if it already exists. Defaults to true
+    updateGithubRelease.set(true)
     
     // Fancy display name for the upload.
     // Will default to the project version if not set

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,9 @@ publisher {
     // Required for Modrinth/GitHub
     setVersion("1.20.2-${project.version}")
     
+    // Tag to use for GitHub release. Defaults to version
+    setGithubTag("v${project.version}")
+    
     // Fancy display name for the upload.
     // Will default to the project version if not set
     setDisplayName("[1.20.x] Simple Discord Link - ${project.version}")
@@ -241,6 +244,9 @@ publisher {
     
     // Required for Modrinth/GitHub
     version.set("1.3.0")
+
+    // Tag to use for GitHub release. Defaults to version
+    githubTag.set("v${project.version}")
     
     // Fancy display name for the upload.
     // Will default to the project version if not set

--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,9 @@ Additional values that can be added to the above:
 ```groovy
 // GitHub options
 github {
+    // GitHub repo to publish to. Overrides githubRepo
+    repo = "OWNER/REPO"
+
     // Tag to use for GitHub release. Defaults to version
     tag = "v${project.version}"
 
@@ -318,6 +321,9 @@ Additional values that can be added to the above:
 ```kotlin
 // GitHub options
 github {
+    // GitHub repo to publish to. Overrides githubRepo
+    repo = "OWNER/REPO"
+    
     // Tag to use for GitHub release. Defaults to version
     tag = "v${project.version}"
 

--- a/src/main/java/com/hypherionmc/modpublisher/plugin/ModPublisherGradleExtension.java
+++ b/src/main/java/com/hypherionmc/modpublisher/plugin/ModPublisherGradleExtension.java
@@ -77,6 +77,9 @@ public class ModPublisherGradleExtension {
     // Modrinth Dependencies
     @Getter private final Dependencies modrinthDepends;
 
+    // Create GitHub tag if missing
+    @Getter private final Property<Boolean> createGithubTag;
+
     // Create GitHub release if missing
     @Getter private final Property<Boolean> createGithubRelease;
 
@@ -131,6 +134,7 @@ public class ModPublisherGradleExtension {
         ListProperty<String> modrinthEmbedded = project.getObjects().listProperty(String.class).empty();
         this.modrinthDepends = new Dependencies(modrinthRequired, modrinthOptional, modrinthIncompatible, modrinthEmbedded);
 
+        this.createGithubTag = project.getObjects().property(Boolean.class).convention(true);
         this.createGithubRelease = project.getObjects().property(Boolean.class).convention(true);
         this.updateGithubRelease = project.getObjects().property(Boolean.class).convention(true);
         this.disableMalwareScanner = project.getObjects().property(Boolean.class).convention(false);

--- a/src/main/java/com/hypherionmc/modpublisher/plugin/ModPublisherGradleExtension.java
+++ b/src/main/java/com/hypherionmc/modpublisher/plugin/ModPublisherGradleExtension.java
@@ -11,6 +11,7 @@ import com.hypherionmc.modpublisher.properties.ModLoader;
 import com.hypherionmc.modpublisher.properties.Platform;
 import com.hypherionmc.modpublisher.properties.ReleaseType;
 import lombok.Getter;
+import lombok.Setter;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
@@ -41,9 +42,6 @@ public class ModPublisherGradleExtension {
     // GitHub Repo. username/repo or URL
     @Getter private final Property<String> githubRepo;
 
-    // GitHub Release tag. defaults to Version
-    @Getter private final Property<String> githubTag;
-
     // Type of release. Valid entries: release, beta, alpha
     @Getter private final Property<String> versionType;
 
@@ -71,20 +69,14 @@ public class ModPublisherGradleExtension {
     // Override Dependencies for Platforms
     @Getter private HashMap<String, Object> artifacts;
 
+    // GitHub options
+    @Getter private final GithubConfig github;
+
     // Curse Dependencies
     @Getter private final Dependencies curseDepends;
 
     // Modrinth Dependencies
     @Getter private final Dependencies modrinthDepends;
-
-    // Create GitHub tag if missing
-    @Getter private final Property<Boolean> createGithubTag;
-
-    // Create GitHub release if missing
-    @Getter private final Property<Boolean> createGithubRelease;
-
-    // Update GitHub release if exists
-    @Getter private final Property<Boolean> updateGithubRelease;
 
     // Disable Jar Scanning
     @Getter private final Property<Boolean> disableMalwareScanner;
@@ -111,13 +103,15 @@ public class ModPublisherGradleExtension {
         this.versionType = project.getObjects().property(String.class).convention("release");
         this.changelog = project.getObjects().property(Object.class);
         this.version = project.getObjects().property(String.class);
-        this.githubTag = project.getObjects().property(String.class).convention(this.version);
         this.displayName = project.getObjects().property(String.class);
         this.gameVersions = project.getObjects().listProperty(String.class).empty();
         this.loaders = project.getObjects().listProperty(String.class).empty();
         this.curseEnvironment = project.getObjects().property(String.class).convention("both");
         this.artifacts = new HashMap<>();
         this.artifact = project.getObjects().property(Object.class);
+
+        // GitHub config
+        this.github = new GithubConfig();
 
         // Control Curseforge Dependencies
         ListProperty<String> curseRequired = project.getObjects().listProperty(String.class).empty();
@@ -134,9 +128,6 @@ public class ModPublisherGradleExtension {
         ListProperty<String> modrinthEmbedded = project.getObjects().listProperty(String.class).empty();
         this.modrinthDepends = new Dependencies(modrinthRequired, modrinthOptional, modrinthIncompatible, modrinthEmbedded);
 
-        this.createGithubTag = project.getObjects().property(Boolean.class).convention(true);
-        this.createGithubRelease = project.getObjects().property(Boolean.class).convention(true);
-        this.updateGithubRelease = project.getObjects().property(Boolean.class).convention(true);
         this.disableMalwareScanner = project.getObjects().property(Boolean.class).convention(false);
         this.disableEmptyJarCheck = project.getObjects().property(Boolean.class).convention(false);
         this.useModrinthStaging = project.getObjects().property(Boolean.class).convention(false);
@@ -173,6 +164,14 @@ public class ModPublisherGradleExtension {
      */
     public void apiKeys(Action<ApiKeys> action) {
         action.execute(apiKeys);
+    }
+
+    /**
+     * Helper Method to create the github extension with DSL
+     * @param action The configured github DSL to apply
+     */
+    public void github(Action<GithubConfig> action) {
+        action.execute(github);
     }
 
     /**
@@ -475,6 +474,34 @@ public class ModPublisherGradleExtension {
         public void changelog(String changelog) {
             this.changelog = changelog;
         }
+    }
+
+    /**
+     * Options related to publishing GitHub Releases
+     */
+    @Getter
+    @Setter
+    public class GithubConfig {
+
+        /**
+         * GitHub Release tag. Defaults to Version
+         */
+        private String tag = ModPublisherGradleExtension.this.version.getOrNull();
+
+        /**
+         * Create GitHub tag if missing
+         */
+        private boolean createTag = true;
+
+        /**
+         * Create GitHub release if missing
+         */
+        private boolean createRelease = true;
+
+        /**
+         * Update GitHub release if exists
+         */
+        private boolean updateRelease = true;
     }
 }
 

--- a/src/main/java/com/hypherionmc/modpublisher/plugin/ModPublisherGradleExtension.java
+++ b/src/main/java/com/hypherionmc/modpublisher/plugin/ModPublisherGradleExtension.java
@@ -41,6 +41,9 @@ public class ModPublisherGradleExtension {
     // GitHub Repo. username/repo or URL
     @Getter private final Property<String> githubRepo;
 
+    // GitHub Release tag. defaults to Version
+    @Getter private final Property<String> githubTag;
+
     // Type of release. Valid entries: release, beta, alpha
     @Getter private final Property<String> versionType;
 
@@ -99,6 +102,7 @@ public class ModPublisherGradleExtension {
         this.versionType = project.getObjects().property(String.class).convention("release");
         this.changelog = project.getObjects().property(Object.class);
         this.version = project.getObjects().property(String.class);
+        this.githubTag = project.getObjects().property(String.class).convention(this.version);
         this.displayName = project.getObjects().property(String.class);
         this.gameVersions = project.getObjects().listProperty(String.class).empty();
         this.loaders = project.getObjects().listProperty(String.class).empty();

--- a/src/main/java/com/hypherionmc/modpublisher/plugin/ModPublisherGradleExtension.java
+++ b/src/main/java/com/hypherionmc/modpublisher/plugin/ModPublisherGradleExtension.java
@@ -77,6 +77,12 @@ public class ModPublisherGradleExtension {
     // Modrinth Dependencies
     @Getter private final Dependencies modrinthDepends;
 
+    // Create GitHub release if missing
+    @Getter private final Property<Boolean> createGithubRelease;
+
+    // Update GitHub release if exists
+    @Getter private final Property<Boolean> updateGithubRelease;
+
     // Disable Jar Scanning
     @Getter private final Property<Boolean> disableMalwareScanner;
 
@@ -125,6 +131,8 @@ public class ModPublisherGradleExtension {
         ListProperty<String> modrinthEmbedded = project.getObjects().listProperty(String.class).empty();
         this.modrinthDepends = new Dependencies(modrinthRequired, modrinthOptional, modrinthIncompatible, modrinthEmbedded);
 
+        this.createGithubRelease = project.getObjects().property(Boolean.class).convention(true);
+        this.updateGithubRelease = project.getObjects().property(Boolean.class).convention(true);
         this.disableMalwareScanner = project.getObjects().property(Boolean.class).convention(false);
         this.disableEmptyJarCheck = project.getObjects().property(Boolean.class).convention(false);
         this.useModrinthStaging = project.getObjects().property(Boolean.class).convention(false);

--- a/src/main/java/com/hypherionmc/modpublisher/plugin/ModPublisherGradleExtension.java
+++ b/src/main/java/com/hypherionmc/modpublisher/plugin/ModPublisherGradleExtension.java
@@ -17,6 +17,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.HashMap;
 
@@ -489,18 +490,28 @@ public class ModPublisherGradleExtension {
         private String tag = ModPublisherGradleExtension.this.version.getOrNull();
 
         /**
+         * GitHub Repo. username/repo or URL
+         * <p>
+         * Overrides {@link ModPublisherGradleExtension#getGithubRepo() githubRepo}
+         */
+        private String repo = ModPublisherGradleExtension.this.githubRepo.getOrNull();
+
+        /**
          * Create GitHub tag if missing
          */
+        @ApiStatus.Experimental
         private boolean createTag = true;
 
         /**
          * Create GitHub release if missing
          */
+        @ApiStatus.Experimental
         private boolean createRelease = true;
 
         /**
          * Update GitHub release if exists
          */
+        @ApiStatus.Experimental
         private boolean updateRelease = true;
     }
 }

--- a/src/main/java/com/hypherionmc/modpublisher/tasks/GithubUploadTask.java
+++ b/src/main/java/com/hypherionmc/modpublisher/tasks/GithubUploadTask.java
@@ -105,6 +105,17 @@ public class GithubUploadTask extends DefaultTask {
                 return;
             }
 
+            if (!extension.getCreateGithubTag().get()) {
+                // FIXME It'd be nice to get tag by name, but GHRepository doesn't expose an API to do that
+                // For now, just iterate thorough all tags on the repo...
+                for (GHTag ghTag : ghRepository.listTags()) {
+                    if (tag.equals(ghTag.getName())) {
+                        project.getLogger().warn("Create tag for GitHub Release is disabled and tag {} already exists", tag);
+                        return;
+                    }
+                }
+            }
+
             GHReleaseBuilder releaseBuilder = new GHReleaseBuilder(ghRepository, tag);
 
             // Use the first non-empty value in [displayName, version, githubTag]

--- a/src/main/java/com/hypherionmc/modpublisher/tasks/GithubUploadTask.java
+++ b/src/main/java/com/hypherionmc/modpublisher/tasks/GithubUploadTask.java
@@ -100,6 +100,11 @@ public class GithubUploadTask extends DefaultTask {
 
         // Existing release was not found, so we create a new one
         if (ghRelease == null) {
+            if (!extension.getCreateGithubRelease().get()) {
+                project.getLogger().warn("Create GitHub Release is disabled and Github Release with tag {} does not exist", tag);
+                return;
+            }
+
             GHReleaseBuilder releaseBuilder = new GHReleaseBuilder(ghRepository, tag);
 
             // Use the first non-empty value in [displayName, version, githubTag]
@@ -115,6 +120,9 @@ public class GithubUploadTask extends DefaultTask {
             releaseBuilder.draft(true);
             releaseBuilder.commitish(ghRepository.getDefaultBranch());
             ghRelease = releaseBuilder.create();
+        } else if (!extension.getUpdateGithubRelease().get()) {
+            project.getLogger().warn("Update GitHub Release is disabled and Github Release with tag {} already exists", tag);
+            return;
         }
 
         if (ghRelease == null)

--- a/src/main/java/com/hypherionmc/modpublisher/tasks/GithubUploadTask.java
+++ b/src/main/java/com/hypherionmc/modpublisher/tasks/GithubUploadTask.java
@@ -86,7 +86,7 @@ public class GithubUploadTask extends DefaultTask {
             return;
         }
 
-        final String uploadRepo = CommonUtil.cleanGithubUrl(extension.getGithubRepo().get());
+        final String uploadRepo = CommonUtil.cleanGithubUrl(extension.getGithub().getRepo());
 
         GHRepository ghRepository = gitHub.getRepository(uploadRepo);
 

--- a/src/main/java/com/hypherionmc/modpublisher/tasks/GithubUploadTask.java
+++ b/src/main/java/com/hypherionmc/modpublisher/tasks/GithubUploadTask.java
@@ -12,8 +12,10 @@ import com.hypherionmc.modpublisher.util.CommonUtil;
 import com.hypherionmc.modpublisher.util.UploadPreChecks;
 import com.hypherionmc.modpublisher.util.UserAgentInterceptor;
 import okhttp3.OkHttpClient;
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskAction;
 import org.kohsuke.github.*;
 import org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector;
@@ -23,6 +25,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
 /**
  * @author HypherionSA
  * Sub-Task to handle GitHub publishing. This task will only be executed if
@@ -86,21 +90,26 @@ public class GithubUploadTask extends DefaultTask {
 
         GHRepository ghRepository = gitHub.getRepository(uploadRepo);
 
+        final String tag = extension.getGithubTag().get();
+
         // Try to find an existing release.
         // If one is found, the file will be added onto it.
-        GHRelease ghRelease = ghRepository.getReleaseByTagName(extension.getVersion().get());
+        GHRelease ghRelease = ghRepository.getReleaseByTagName(tag);
 
         UploadPreChecks.checkEmptyJar(extension, uploadFile, extension.getLoaders().get());
 
         // Existing release was not found, so we create a new one
         if (ghRelease == null) {
-            GHReleaseBuilder releaseBuilder = new GHReleaseBuilder(ghRepository, extension.getVersion().get());
+            GHReleaseBuilder releaseBuilder = new GHReleaseBuilder(ghRepository, tag);
 
-            if (extension.getDisplayName().isPresent() && !extension.getDisplayName().get().isEmpty()) {
-                releaseBuilder.name(extension.getDisplayName().get());
-            } else {
-                releaseBuilder.name(extension.getVersion().get());
-            }
+            // Use the first non-empty value in [displayName, version, githubTag]
+            String name = Stream.of(extension.getDisplayName(), extension.getVersion())
+                    .map(Provider::getOrNull)
+                    .filter(StringUtils::isNotBlank)
+                    .findFirst()
+                    .orElse(tag);
+
+            releaseBuilder.name(name);
 
             releaseBuilder.body(CommonUtil.resolveString(extension.getChangelog().get()));
             releaseBuilder.draft(true);
@@ -109,7 +118,7 @@ public class GithubUploadTask extends DefaultTask {
         }
 
         if (ghRelease == null)
-            throw new NullPointerException("Could not get existing or create new Github Release with tag " +  extension.getVersion().get());
+            throw new NullPointerException("Could not get existing or create new Github Release with tag " + tag);
 
         GHAsset asset = ghRelease.uploadAsset(uploadFile, "application/octet-stream");
 
@@ -130,8 +139,9 @@ public class GithubUploadTask extends DefaultTask {
         releaseUpdater.update();
 
         project.getLogger().lifecycle(
-                "Successfully uploaded version {} to {}. {}.",
-                extension.getVersion().get(),
+                "Successfully uploaded {} (tag {}) to {}. {}.",
+                extension.getVersion().map(v -> "version " + v).getOrElse("(empty version)"),
+                tag,
                 ghRepository.getUrl().toString(),
                 ghRelease.getHtmlUrl().toString()
         );

--- a/src/main/java/com/hypherionmc/modpublisher/tasks/GithubUploadTask.java
+++ b/src/main/java/com/hypherionmc/modpublisher/tasks/GithubUploadTask.java
@@ -90,7 +90,7 @@ public class GithubUploadTask extends DefaultTask {
 
         GHRepository ghRepository = gitHub.getRepository(uploadRepo);
 
-        final String tag = extension.getGithubTag().get();
+        final String tag = extension.getGithub().getTag();
 
         // Try to find an existing release.
         // If one is found, the file will be added onto it.
@@ -100,12 +100,12 @@ public class GithubUploadTask extends DefaultTask {
 
         // Existing release was not found, so we create a new one
         if (ghRelease == null) {
-            if (!extension.getCreateGithubRelease().get()) {
+            if (!extension.getGithub().isCreateRelease()) {
                 project.getLogger().warn("Create GitHub Release is disabled and Github Release with tag {} does not exist", tag);
                 return;
             }
 
-            if (!extension.getCreateGithubTag().get()) {
+            if (!extension.getGithub().isCreateTag()) {
                 // FIXME It'd be nice to get tag by name, but GHRepository doesn't expose an API to do that
                 // For now, just iterate thorough all tags on the repo...
                 for (GHTag ghTag : ghRepository.listTags()) {
@@ -131,7 +131,7 @@ public class GithubUploadTask extends DefaultTask {
             releaseBuilder.draft(true);
             releaseBuilder.commitish(ghRepository.getDefaultBranch());
             ghRelease = releaseBuilder.create();
-        } else if (!extension.getUpdateGithubRelease().get()) {
+        } else if (!extension.getGithub().isUpdateRelease()) {
             project.getLogger().warn("Update GitHub Release is disabled and Github Release with tag {} already exists", tag);
             return;
         }

--- a/src/main/java/com/hypherionmc/modpublisher/util/UploadPreChecks.java
+++ b/src/main/java/com/hypherionmc/modpublisher/util/UploadPreChecks.java
@@ -12,11 +12,13 @@ import com.hypherionmc.modpublisher.util.scanner.JarInfectionScanner;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
 
 import java.io.File;
 import java.nio.file.*;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 public class UploadPreChecks {
 
@@ -82,6 +84,10 @@ public class UploadPreChecks {
         if (StringUtils.isBlank(extension.getGithubTag().getOrNull())) {
             // githubTag defaults to version; if tag is missing, so is version
             throw new Exception("Neither Version or GithubTag are defined. At least one is REQUIRED by github");
+        }
+
+        if (Stream.of(extension.getCreateGithubRelease(), extension.getUpdateGithubRelease()).noneMatch(Property::get)) {
+            throw new Exception("createGithubRelease and updateGithubRelease are both disabled, at least one must be enabled");
         }
 
         if (extension.getApiKeys() != null && !extension.getApiKeys().getGithub().isEmpty()) {

--- a/src/main/java/com/hypherionmc/modpublisher/util/UploadPreChecks.java
+++ b/src/main/java/com/hypherionmc/modpublisher/util/UploadPreChecks.java
@@ -17,6 +17,7 @@ import org.gradle.api.provider.Property;
 import java.io.File;
 import java.nio.file.*;
 import java.util.List;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -81,13 +82,13 @@ public class UploadPreChecks {
         if (extension == null)
             return false;
 
-        if (StringUtils.isBlank(extension.getGithubTag().getOrNull())) {
-            // githubTag defaults to version; if tag is missing, so is version
-            throw new Exception("Neither Version or GithubTag are defined. At least one is REQUIRED by github");
+        if (StringUtils.isBlank(extension.getGithub().getTag())) {
+            // tag defaults to version; if tag is missing, so is version
+            throw new Exception("Neither Version or GitHub Tag are defined. At least one is REQUIRED by github");
         }
 
-        if (Stream.of(extension.getCreateGithubRelease(), extension.getUpdateGithubRelease()).noneMatch(Property::get)) {
-            throw new Exception("createGithubRelease and updateGithubRelease are both disabled, at least one must be enabled");
+        if (!(extension.getGithub().isCreateRelease() || extension.getGithub().isUpdateRelease())) {
+            throw new Exception("Github options createRelease and updateRelease are both disabled, at least one must be enabled");
         }
 
         if (extension.getApiKeys() != null && !extension.getApiKeys().getGithub().isEmpty()) {

--- a/src/main/java/com/hypherionmc/modpublisher/util/UploadPreChecks.java
+++ b/src/main/java/com/hypherionmc/modpublisher/util/UploadPreChecks.java
@@ -92,8 +92,8 @@ public class UploadPreChecks {
         }
 
         if (extension.getApiKeys() != null && !extension.getApiKeys().getGithub().isEmpty()) {
-            if (!extension.getGithubRepo().isPresent() || extension.getGithubRepo().get().isEmpty()) {
-                throw new Exception("Found GitHub token, but githubRepo is not defined");
+            if (StringUtils.isBlank(extension.getGithub().getRepo())) {
+                throw new Exception("Found GitHub token, but github repo is not defined");
             } else {
                 return true;
             }

--- a/src/main/java/com/hypherionmc/modpublisher/util/UploadPreChecks.java
+++ b/src/main/java/com/hypherionmc/modpublisher/util/UploadPreChecks.java
@@ -9,6 +9,7 @@ package com.hypherionmc.modpublisher.util;
 import com.hypherionmc.modpublisher.plugin.ModPublisherGradleExtension;
 import com.hypherionmc.modpublisher.properties.Platform;
 import com.hypherionmc.modpublisher.util.scanner.JarInfectionScanner;
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 
@@ -40,12 +41,6 @@ public class UploadPreChecks {
         }
     }
 
-    public static void checkVersion(Project project, ModPublisherGradleExtension extension) throws Exception {
-        if (!extension.getVersion().isPresent() || extension.getVersion().get().isEmpty()) {
-            throw new Exception("Version is not defined. This is REQUIRED by modrinth/github");
-        }
-    }
-
     public static boolean canUploadCurse(Project project, ModPublisherGradleExtension extension) throws Exception {
         if (extension == null)
             return false;
@@ -65,7 +60,10 @@ public class UploadPreChecks {
         if (extension == null)
             return false;
 
-        checkVersion(project, extension);
+        if (StringUtils.isBlank(extension.getVersion().getOrNull())) {
+            throw new Exception("Version is not defined. This is REQUIRED by modrinth");
+        }
+
         // Check that both the Modrinth API key and Project ID is defined
         if (extension.getApiKeys() != null && !extension.getApiKeys().getModrinth().isEmpty()) {
             if (!extension.getModrinthID().isPresent() || extension.getModrinthID().get().isEmpty()) {
@@ -81,7 +79,11 @@ public class UploadPreChecks {
         if (extension == null)
             return false;
 
-        checkVersion(project, extension);
+        if (StringUtils.isBlank(extension.getGithubTag().getOrNull())) {
+            // githubTag defaults to version; if tag is missing, so is version
+            throw new Exception("Neither Version or GithubTag are defined. At least one is REQUIRED by github");
+        }
+
         if (extension.getApiKeys() != null && !extension.getApiKeys().getGithub().isEmpty()) {
             if (!extension.getGithubRepo().isPresent() || extension.getGithubRepo().get().isEmpty()) {
                 throw new Exception("Found GitHub token, but githubRepo is not defined");

--- a/testprojects/groovytest/build.gradle
+++ b/testprojects/groovytest/build.gradle
@@ -55,6 +55,13 @@ publisher {
         changelog "Hello Changelog"
     }
 
+    github {
+        tag = "v${project.version}"
+        createTag = true
+        createRelease = true
+        updateRelease = true
+    }
+
     modrinthDepends {
         required "fabric-api", "craterlib"
         required "fabric-api"

--- a/testprojects/kotlintest/build.gradle.kts
+++ b/testprojects/kotlintest/build.gradle.kts
@@ -62,6 +62,13 @@ publisher {
         changelog("Some Changelog")
     }
 
+    github {
+        tag = "v${project.version}"
+        createTag = true
+        createRelease = true
+        updateRelease = true
+    }
+
     curseDepends {
         required("fabric-api", "craterlib")
         optional("optional-mod", "another-mod")


### PR DESCRIPTION
Motivated by #7, introduce some basic control over how GitHub Releases are published.

- Allow configuring whether missing/existing releases are created/updated
- Allow publishing to a tag that is different to `version`

I'm fairly unfamiliar with your codebase, so feel free to propose changes, push commits here, or discard this PR in favour of your own implementation.