### PR TITLE
More github options (`draft` and `target`)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### Version 2.1.1
+
+* [FEAT] GitHub release `draft` and `target` options - [#11](https://github.com/firstdarkdev/modpublisher/pull/11) - MattSturgeon
+
 ### Version 2.1.0
 
 * [BUG] Fixed Modrinth Uploads failing when using ModLoaders enum - HypherionSA

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version_base=2.1
-version_patch=0
+version_patch=1
 
 # Dependencies
 curse4j=1.0.10

--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,20 @@ github {
 
     // Whether to update the GitHub release if it already exists. Defaults to true
     updateRelease = true
+
+    // Whether the release should be left as an unpublished draft.
+    //
+    // If enabled, newly created releases and existing drafts will not be published.
+    // Instead, a draft release is used.
+    //
+    // If disabled, the release will be published.
+    // This option does not allow converting a published release to a draft.
+    //
+    // Defaults to false
+    draft = false
+
+    // The commitish ref the tag should target (ignored when tag already exists)
+    target = "main"
 }
 
 // Modrinth Dependencies.
@@ -337,6 +351,20 @@ github {
 
     // Whether to update the GitHub release if it already exists. Defaults to true
     updateRelease = true
+
+    // Whether the release should be left as an unpublished draft.
+    //
+    // If enabled, newly created releases and existing drafts will not be published.
+    // Instead, a draft release is used.
+    //
+    // If disabled, the release will be published.
+    // This option does not allow converting a published release to a draft.
+    //
+    // Defaults to false
+    draft = false
+
+    // The commitish ref the tag should target (ignored when tag already exists)
+    target = "main"
 }
 
 // Modrinth Dependencies.

--- a/src/main/java/com/hypherionmc/modpublisher/plugin/ModPublisherGradleExtension.java
+++ b/src/main/java/com/hypherionmc/modpublisher/plugin/ModPublisherGradleExtension.java
@@ -11,7 +11,6 @@ import com.hypherionmc.modpublisher.properties.ModLoader;
 import com.hypherionmc.modpublisher.properties.Platform;
 import com.hypherionmc.modpublisher.properties.ReleaseType;
 import lombok.Getter;
-import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
@@ -20,6 +19,7 @@ import org.gradle.api.Project;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 
@@ -500,7 +500,6 @@ public class ModPublisherGradleExtension {
      * Options related to publishing GitHub Releases
      */
     @Getter
-    @Setter
     public class GithubConfig {
 
         /**
@@ -509,11 +508,33 @@ public class ModPublisherGradleExtension {
         private String tag = ModPublisherGradleExtension.this.projectVersion.getOrNull();
 
         /**
+         * Optional commitish ref that the release tag will point to. Ignored if tag already exists.
+         * <p>
+         * If {@code null}, the default branch is used.
+         */
+        private @Nullable String target = null;
+
+        /**
          * GitHub Repo. username/repo or URL
          * <p>
          * Overrides {@link ModPublisherGradleExtension#getGithubRepo() githubRepo}
          */
         private String repo = ModPublisherGradleExtension.this.githubRepo.getOrNull();
+
+        /**
+         * Mark whether the release is a draft (unpublished)
+         * <p>
+         * If {@code true}, newly created releases and existing drafts will not be published.
+         * Instead, a draft release is used.
+         * <p>
+         * If {@code false}, the release will be published.
+         * <p>
+         * Existing <em>published</em> releases are always unaffected;
+         * This option does not allow converting a published release to a draft.
+         * <p>
+         * Defaults to {@code false}
+         */
+        private boolean draft = false;
 
         /**
          * Create GitHub tag if missing
@@ -532,6 +553,69 @@ public class ModPublisherGradleExtension {
          */
         @ApiStatus.Experimental
         private boolean updateRelease = true;
+
+        /**
+         * Kotlin Compatibility setter
+         * Set GitHub Release tag. Defaults to Version
+         * @param tag The tag to target
+         */
+        public void tag(String tag) {
+            this.tag = tag;
+        }
+
+        /**
+         * Kotlin Compatibility setter
+         * Should the release be marked as a draft
+         * @param isDraft Is this a draft release
+         */
+        public void draft(boolean isDraft) {
+            this.draft = isDraft;
+        }
+
+        /**
+         * Kotlin Compatibility setter
+         * Should the GitHub tag be created if it doesn't exist
+         * @param createTag Create the tag
+         */
+        public void createTag(boolean createTag) {
+            this.createTag = createTag;
+        }
+
+        /**
+         * Kotlin Compatibility setter
+         * Should the GitHub release be created if it doesn't exist
+         * @param createRelease Create the release
+         */
+        public void createRelease(boolean createRelease) {
+            this.createRelease = createRelease;
+        }
+
+        /**
+         * Kotlin Compatibility setter
+         * Should the release be updated, if it already exists on the repo
+         * @param updateRelease Update the release
+         */
+        public void updateRelease(boolean updateRelease) {
+            this.updateRelease = updateRelease;
+        }
+
+        /**
+         * Kotlin Compatibility setter
+         * Define the branch to target when creating tags and releases
+         * @param target The name of the branch to target
+         */
+        public void target(String target) {
+            this.target = target;
+        }
+
+        /**
+         * Kotlin Compatibility setter
+         * Override the Repo URL used for publishing
+         * @param repo The repo to publish to. Defaults to {@link ModPublisherGradleExtension#getGithubRepo() githubRepo}
+         */
+        public void repo(String repo) {
+            this.repo = repo;
+        }
     }
 }
 

--- a/testprojects/groovytest/build.gradle
+++ b/testprojects/groovytest/build.gradle
@@ -56,10 +56,10 @@ publisher {
     }
 
     github {
-        tag = "v${project.version}"
-        createTag = true
-        createRelease = true
-        updateRelease = true
+        tag("v${project.version}")
+        createTag(true)
+        createRelease(true)
+        updateRelease(true)
     }
 
     modrinthDepends {

--- a/testprojects/kotlintest/build.gradle.kts
+++ b/testprojects/kotlintest/build.gradle.kts
@@ -63,10 +63,10 @@ publisher {
     }
 
     github {
-        tag = "v${project.version}"
-        createTag = true
-        createRelease = true
-        updateRelease = true
+        tag("v${project.version}")
+        createTag(true)
+        createRelease(true)
+        updateRelease(true)
     }
 
     curseDepends {


### PR DESCRIPTION
#### Following on from #8:

> It'd also be nice to expose configuring whether the release is a draft, and the "commitish" used when creating a new tag. Perhaps in a future PR...

Welcome to the future :rocket: 

#### Introduce some additional control over the GitHub Release publishing:

- Allow configuring whether to keep the release as a draft.
- Allow configuring the `target_commitish`; used if GitHub creates the
release's tag.

Note: I wasn't using my normal machine when working on this, so it's currently in untested-draft status 😃

I'm going to say this fixes #7. That issue is probably too vague to be useful going forward; the available options can _always_ be improved.
