### PR TITLE
Fix & improve `github.createTag`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### Version 2.1.2
+
+* [FIX] GitHub release `createTag` option was broken - [#15](https://github.com/firstdarkdev/modpublisher/pull/15) - MattSturgeon
+
 ### Version 2.1.1
 
 * [FEAT] GitHub release `draft` and `target` options - [#11](https://github.com/firstdarkdev/modpublisher/pull/11) - MattSturgeon

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version_base=2.1
-version_patch=1
+version_patch=2
 
 # Dependencies
 curse4j=1.0.10


### PR DESCRIPTION
Fixed the inverted logic and avoided the need to fetch all repo tags by using `getRef` instead.

I tested out the [`hasRef` implementation](https://github.com/firstdarkdev/modpublisher/pull/15/files#diff-1547efb0ef96fae2452eb434ab9306b94511b1065ccf92c9e6187c90bb870842R176-R195) as follows:

<details><summary>Details</summary>
<p>

```kotlin
// Some boilerplate setting up github, token & repo omitted
fun main() {
    sequenceOf("v1.2.3", "foo", "random", "v1.2.2", "v1.2.3+mc1.20.4")
        .forEach {
            println("Checking if ${repo.fullName} has tag named $it")
            val has = repo.hasTag(it)
            println("  It ${if (has) "does" else "does not"}!")
        }

}

fun GHRepository.hasTag(tag: String): Boolean {
    try {
        this.getRef("refs/tags/$tag")
        return true
    } catch (e: GHFileNotFoundException) {
        return false
    } catch (e: IOException) {
        throw IOException("Error checking remote tag", e)
    }
}
```

Which prints:

```
Checking if MinecraftFreecam/Freecam has tag named v1.2.3
  It does!
Checking if MinecraftFreecam/Freecam has tag named foo
  It does not!
Checking if MinecraftFreecam/Freecam has tag named random
  It does not!
Checking if MinecraftFreecam/Freecam has tag named v1.2.2
  It does!
Checking if MinecraftFreecam/Freecam has tag named v1.2.3+mc1.20.4
  It does!
```

</p>
</details> 

Fixes #12
Fixes #14
