### PR TITLE
[FIX] support `neoforge.mods.toml`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### Version 2.1.3
+
+* [FIX] Support neoforge's `neoforge.mods.toml` file introduced in 20.5.0 - MattSturgeon
+
 ### Version 2.1.2
 
 * [FIX] GitHub release `createTag` option was broken - [#15](https://github.com/firstdarkdev/modpublisher/pull/15) - MattSturgeon

--- a/src/main/java/com/hypherionmc/modpublisher/util/UploadPreChecks.java
+++ b/src/main/java/com/hypherionmc/modpublisher/util/UploadPreChecks.java
@@ -112,12 +112,13 @@ public class UploadPreChecks {
         Path quiltJson = system.getPath("quilt.mod.json");
         Path fabricJson = system.getPath("fabric.mod.json");
         Path forgeToml = system.getPath("META-INF/mods.toml");
+        Path neoforgeToml = system.getPath("META-INF/neoforge.mods.toml");
         Path forgeMc = system.getPath("mcmod.info");
 
         if (loaderVersions.contains("forge") || loaderVersions.contains("neoforge")) {
             // Check for either mods.toml or mcmod.info (for older version support)
-            if (!Files.exists(forgeToml) && !Files.exists(forgeMc))
-                throw new GradleException("File marked as forge/neoforge, but no mods.toml or mcmod.info file was found");
+            if (!Files.exists(neoforgeToml) && !Files.exists(forgeToml) && !Files.exists(forgeMc))
+                throw new GradleException("File marked as forge/neoforge, but no neoforge.mods.toml, mods.toml or mcmod.info file was found");
         }
 
         if (loaderVersions.contains("fabric")) {


### PR DESCRIPTION
Neoforge 20.5.0-beta (needed for 1.20.5) moved from `mods.toml` to `neoforge.mods.toml`.

This PR updates the upload pre-checks to support that.