### PR TITLE
[DEV] configure gradle toolchain resolver

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,7 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
+}
 rootProject.name = 'modpublisher'


### PR DESCRIPTION
Allows gradle to download the appropriate Java toolchain when the configured version isn't found locally.