### PR TITLE
[FIX] Find draft GitHub releases using tag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,14 @@
+### Version 2.1.7
+
+* [Fix] - Find draft GitHub releases using tag [#26](https://github.com/firstdarkdev/modpublisher/pull/26)
+
+### Version 2.1.6
+
+* [FEAT] Add support for our NightBloom download platform
+
 ### Version 2.1.5
 
 * [FEAT] Add support for "draft" uploads for Modrinth and CurseForge - HypherionSA
-* [FEAT] Add support for our NightBloom download platform
 
 ### Version 2.1.4
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,8 @@
 version_major=2
 version_minor=1
-version_patch=5
-release_type=release
+version_patch=7
+version_build=0
+release_type=snapshot
 
 # Dependencies
 curse4j=1.0.11

--- a/src/main/java/com/hypherionmc/modpublisher/tasks/GithubUploadTask.java
+++ b/src/main/java/com/hypherionmc/modpublisher/tasks/GithubUploadTask.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -95,7 +96,7 @@ public class GithubUploadTask extends DefaultTask {
 
         // Try to find an existing release.
         // If one is found, the file will be added onto it.
-        GHRelease ghRelease = ghRepository.getReleaseByTagName(tag);
+        GHRelease ghRelease = getRelease(ghRepository, tag);
 
         UploadPreChecks.checkEmptyJar(extension, uploadFile, extension.getLoaders().get());
 
@@ -173,6 +174,24 @@ public class GithubUploadTask extends DefaultTask {
                 ghRepository.getUrl().toString(),
                 ghRelease.getHtmlUrl().toString()
         );
+    }
+
+    private static GHRelease getRelease(GHRepository repo, String tag) throws IOException {
+        // First, attempt to get the tag using the releases/tags/<tag> endpoint
+        GHRelease attempt1 = repo.getReleaseByTagName(tag);
+        if (attempt1 != null) {
+            return attempt1;
+        }
+
+        // For draft releases we need to do some additional work...
+        // Scan all releases for one with a matching tag name
+        for (GHRelease release : repo.listReleases()) {
+            if (Objects.equals(tag, release.getTagName())) {
+                return release;
+            }
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Draft releases are not found at the `releases/tags/<tag>` endpoint, but are still associated with the tag name.

If we can't find a release at `releases/tags/<tag>`, then we iterate through all releases looking for one with a matching tag name.

It may be better to come up with a GraphQL query instead of iterating through all releases via the REST API?

The GH CLI implements release fetching as: https://github.com/cli/cli/blob/30066b0042d0c5928d959e288144300cb28196c9/pkg/cmd/release/shared/fetch.go#L134-L161

The draft release lookup uses a GraphQL query: https://github.com/cli/cli/blob/30066b0042d0c5928d959e288144300cb28196c9/pkg/cmd/release/shared/fetch.go#L169-L200

Currently I'm unsure of what the best way to make a GraphQL request is in kohsuke github, although I wonder if this is fine as a stopgap here and fetching draft releases should later be implemented upstream using GraphQL?

I've opened https://github.com/hub4j/github-api/issues/1983 upstream.
